### PR TITLE
Fixed playlist tracks retrieval through the web API.

### DIFF
--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -29,7 +29,8 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         return images.get_images(self._backend._web_client, uris)
 
     def lookup(self, uri):
-        return lookup.lookup(self._config, self._backend._session, uri)
+        return lookup.lookup(self._config, self._backend._session, uri,
+                             self._backend._web_client)
 
     def search(self, query=None, uris=None, exact=False):
         return search.search(

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -14,7 +14,7 @@ _VARIOUS_ARTISTS_URIS = [
 ]
 
 
-def lookup(config, session, uri):
+def lookup(config, session, uri, web_client):
     try:
         web_link = translator.parse_uri(uri)
         sp_link = session.get_link(uri)

--- a/mopidy_spotify/playlists.py
+++ b/mopidy_spotify/playlists.py
@@ -98,7 +98,8 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
 
         username = self._backend._session.user_name
 
-        result = self._backend._web_client.get('me/playlists')
+        result = self._backend._web_client.get('me/playlists', params={
+            'limit': 50 })
 
         if result is None:
             logger.error("No playlists found") # is this an error condition or normal?
@@ -153,10 +154,10 @@ class SpotifyPlaylistsProvider(backend.PlaylistsProvider):
                 'users/%s/playlists/%s' % (link.owner, link.id),
                 params=params)
 
-            if web_playlist is not None:
-                if as_items and 'tracks' in web_playlist:
-                    all_tracks = self._get_all_items(web_playlist['tracks']['items'])
-                    web_playlist['tracks'] = [t['track'] for t in all_tracks]
+            if web_playlist is not None and 'tracks' in web_playlist:
+                web_playlist['tracks'] = [
+                    t['track'] for t in
+                    self._get_all_items(web_playlist['tracks'])]
 
         if web_playlist is None:
             logger.debug('Failed to lookup Spotify URI %s', uri)

--- a/mopidy_spotify/search.py
+++ b/mopidy_spotify/search.py
@@ -25,7 +25,7 @@ def search(config, session, web_client,
         return models.SearchResult(uri='spotify:search')
 
     if 'uri' in query:
-        return _search_by_uri(config, session, query)
+        return _search_by_uri(config, session, query, web_client)
 
     sp_query = translator.sp_search_query(query)
     if not sp_query:
@@ -77,10 +77,10 @@ def search(config, session, web_client,
         uri=uri, albums=albums, artists=artists, tracks=tracks)
 
 
-def _search_by_uri(config, session, query):
+def _search_by_uri(config, session, query, web_client):
     tracks = []
     for uri in query['uri']:
-        tracks += lookup.lookup(config, session, uri)
+        tracks += lookup.lookup(config, session, uri, web_client)
 
     uri = 'spotify:search'
     if len(query['uri']) == 1:

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -283,39 +283,15 @@ def web_to_playlist_ref(web_playlist, folders=None, username=None):
 
 
 def web_to_playlist(web_playlist, folders=None, username=None, bitrate=None,
-        as_ref=False, as_items=False, web_client=None):
-    def _get_all_items(first_result, params=None):
-        # TODO this logic is more or less copied from playlists.py,
-        # refactor the code to do the playlist expansion playlist only once
-        if params is None:
-            params = {}
-        items = first_result['items']
-        uri = first_result['next']
-        while uri is not None:
-            logger.error("DOING NEXT")
-            next_result = web_client.get(uri, params=params)
-            items.extend(next_result['items'])
-            uri = next_result.get('next', None)
-        return items
-
+        as_ref=False, as_items=False):
     if web_playlist['type'] != 'playlist':
         return
 
     if 'tracks' in web_playlist:
         web_tracks = web_playlist['tracks']
-        if isinstance(web_tracks, dict):
-            if 'items' in web_tracks:
-                web_tracks = [t['track'] for t in _get_all_items(web_tracks)]
-                web_playlist['tracks'] = web_tracks
-            elif 'href' in web_tracks and web_client:
-                web_tracks = web_client.get(
-                    web_playlist['tracks']['href'], params = {'fields':'tracks'})
-
-                if web_tracks and web_tracks['tracks']:
-                    web_tracks = [t['track'] for t in _get_all_items(web_tracks)]
-                    web_playlist['tracks'] = web_tracks
-        else:
-            web_tracks = web_playlist['tracks']
+        if isinstance(web_tracks, dict) and 'items' in web_tracks:
+            web_tracks = [t['track'] for t in web_tracks['items']]
+            web_playlist['tracks'] = web_tracks
     else:
         web_tracks = []
 

--- a/mopidy_spotify/translator.py
+++ b/mopidy_spotify/translator.py
@@ -284,6 +284,20 @@ def web_to_playlist_ref(web_playlist, folders=None, username=None):
 
 def web_to_playlist(web_playlist, folders=None, username=None, bitrate=None,
         as_ref=False, as_items=False, web_client=None):
+    def _get_all_items(first_result, params=None):
+        # TODO this logic is more or less copied from playlists.py,
+        # refactor the code to do the playlist expansion playlist only once
+        if params is None:
+            params = {}
+        items = first_result['items']
+        uri = first_result['next']
+        while uri is not None:
+            logger.error("DOING NEXT")
+            next_result = web_client.get(uri, params=params)
+            items.extend(next_result['items'])
+            uri = next_result.get('next', None)
+        return items
+
     if web_playlist['type'] != 'playlist':
         return
 
@@ -291,13 +305,15 @@ def web_to_playlist(web_playlist, folders=None, username=None, bitrate=None,
         web_tracks = web_playlist['tracks']
         if isinstance(web_tracks, dict):
             if 'items' in web_tracks:
-                web_tracks = [t['track'] for t in web_tracks['items']]
+                web_tracks = [t['track'] for t in _get_all_items(web_tracks)]
+                web_playlist['tracks'] = web_tracks
             elif 'href' in web_tracks and web_client:
                 web_tracks = web_client.get(
                     web_playlist['tracks']['href'], params = {'fields':'tracks'})
 
                 if web_tracks and web_tracks['tracks']:
-                    web_tracks = [t['track'] for t in web_tracks['tracks']['items']]
+                    web_tracks = [t['track'] for t in _get_all_items(web_tracks)]
+                    web_playlist['tracks'] = web_tracks
         else:
             web_tracks = web_playlist['tracks']
     else:


### PR DESCRIPTION
The format returned by `/user/<user_id>/playlists/<playlist_id>` is
actually something like `{ ... "tracks": {"items": [{...}] } ... }`.

The "summarized" playlist output returned by `/me/playlists` instead
describes the tracks through their href:
`{ ... "tracks": {"total"123, "href": "https://api.spotify.com/v1/users/me/playlists/<id>/tracks" ... } }`