### PR TITLE
Fix browse and lookup for Playlists

### DIFF
--- a/mopidy_spotify/browse.py
+++ b/mopidy_spotify/browse.py
@@ -36,15 +36,15 @@ _TOPLIST_REGIONS = {
 }
 
 
-def browse(config, session, uri):
+def browse(config, backend, uri):
     if uri == ROOT_DIR.uri:
         return _ROOT_DIR_CONTENTS
     elif uri.startswith('spotify:user:'):
-        return _browse_playlist(session, uri, config)
+        return _browse_playlist(backend.playlists, uri, config)
     elif uri.startswith('spotify:album:'):
-        return _browse_album(session, uri, config)
+        return _browse_album(backend.session, uri, config)
     elif uri.startswith('spotify:artist:'):
-        return _browse_artist(session, uri, config)
+        return _browse_artist(backend.session, uri, config)
     elif uri.startswith('spotify:top:'):
         parts = uri.replace('spotify:top:', '').split(':')
         if len(parts) == 1:
@@ -61,12 +61,8 @@ def browse(config, session, uri):
         return []
 
 
-def _browse_playlist(session, uri, config):
-    sp_playlist = session.get_playlist(uri)
-    sp_playlist.load(config['timeout'])
-    return list(translator.to_track_refs(
-        sp_playlist.tracks, timeout=config['timeout']))
-
+def _browse_playlist(playlists, uri, config):
+    return playlists.get_items(uri)
 
 def _browse_album(session, uri, config):
     sp_album_browser = session.get_album(uri).browse()

--- a/mopidy_spotify/library.py
+++ b/mopidy_spotify/library.py
@@ -18,7 +18,7 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
         self._config = backend._config['spotify']
 
     def browse(self, uri):
-        return browse.browse(self._config, self._backend._session, uri)
+        return browse.browse(self._config, self._backend, uri)
 
     def get_distinct(self, field, query=None):
         return distinct.get_distinct(
@@ -26,7 +26,7 @@ class SpotifyLibraryProvider(backend.LibraryProvider):
             self._backend._web_session._client, field, query)
 
     def get_images(self, uris):
-        return images.get_images(self._backend._web_session._client, uris)
+        return images.get_images(self._backend._web_session,_client, uris)
 
     def lookup(self, uri):
         return lookup.lookup(

--- a/mopidy_spotify/lookup.py
+++ b/mopidy_spotify/lookup.py
@@ -89,7 +89,7 @@ def _lookup_artist(config, sp_link):
                 yield track
 
 
-def lookup_playlist(session, web_session, config, uri):
+def _lookup_playlist(session, web_session, config, uri):
     playlist = playlists.playlist_lookup(
             session, web_session, uri, config['bitrate'])
     if playlist is None:


### PR DESCRIPTION
This PR fixes the ability to lookup/browse playlist tracks from library methods on new web playlists.
For `library.lookup` it was a typo on `_lookup_playlist` (missing `_`)
For `library.browse` I had to pass `backend` to the function to access `playlist` methods